### PR TITLE
change base image to jenkins/jenkins:lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins
+FROM jenkins/jenkins:lts
 
 USER root
 


### PR DESCRIPTION
jenkins image has been deprecated in favor of the jenkins/jenkins:lts image provided and maintained by Jenkins Community